### PR TITLE
fix(composer.json) : Fixing EOF error composer.json for packagist.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,4 +74,4 @@
         "source": "https://github.com/senasgr-eth/laravel-kodexplorer"
     }
 }
-}
+


### PR DESCRIPTION
Packagist says EOF and can't recognize the repo.

Error on installation both manually and through composer.